### PR TITLE
Fixed undo functionality with checks for edge cases

### DIFF
--- a/app/database.php
+++ b/app/database.php
@@ -1,5 +1,9 @@
 <?php
 
+if (!isset($_SESSION)) {
+    session_start();
+}
+
 function get_state()
 {
     return serialize([$_SESSION['hand'], $_SESSION['board'], $_SESSION['player']]);
@@ -11,6 +15,17 @@ function set_state($state)
     $_SESSION['hand'] = $a;
     $_SESSION['board'] = $b;
     $_SESSION['player'] = $c;
+}
+function getPreviousMove($state)
+    {
+        var_dump($state);
+        $state->prepare('SELECT * FROM moves WHERE id = ?');
+        return $state->get_result()->fetch_array();
+    }
+
+function DeleteMove($state, $lastMoveId){
+    $query = 'DELETE FROM moves WHERE id = ' . intval($lastMoveId);
+    $state->query($query);
 }
 
 return new mysqli('app-db', 'root', '', 'hive');

--- a/app/restart.php
+++ b/app/restart.php
@@ -1,15 +1,20 @@
 <?php
 
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
+function restart(){
 $_SESSION['board'] = [];
 $_SESSION['hand'] = [0 => ["Q" => 1, "B" => 2, "S" => 2, "A" => 3, "G" => 3], 1 => ["Q" => 1, "B" => 2, "S" => 2, "A" => 3, "G" => 3]];
 $_SESSION['player'] = 0;
-
+unset($_SESSION['last_move']);
 
 
 $db = include_once 'database.php';
 $db->prepare('INSERT INTO games VALUES ()')->execute();
 $_SESSION['game_id'] = $db->insert_id;
-
 header('Location: index.php');
+}
+restart();
+

--- a/app/tests/bug_tests.php
+++ b/app/tests/bug_tests.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 require_once 'app/util.php';
+require_once 'app/undo.php';
 
 class bug_tests extends TestCase
 {
@@ -17,4 +18,12 @@ class bug_tests extends TestCase
         $this->assertEquals(true, AvailablePosition($board, $hand[$player],$player, $to[1]));
         $this->assertEquals(false, AvailablePosition($board, $hand[$player],$player, $to[2]));
     }
+
+    public function UndoFirstTry(){
+        session_start();
+        unset($_SESSION["last_move"]);
+
+        $this->assertSame("You must play first", $_SESSION['error']);
+    }
+
 }

--- a/app/undo.php
+++ b/app/undo.php
@@ -1,11 +1,33 @@
 <?php
 
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
+    if(isset($_SESSION['last_move'])){
+        $db = include 'database.php';
+        $stmt = $db->prepare('SELECT * FROM moves WHERE id = '.$_SESSION['last_move']);
+        $stmt->execute();
+        $result = $stmt->get_result()->fetch_array();
+        if ($result !== null) {
+            DeleteMove($db, $_SESSION['last_move']);
+    
+            $_SESSION['last_move'] = $result['previous_id'];
+        } else {
+            $_SESSION['error'] = "No previous move found";
+        }
+        
+        if($result['previous_id'] == null){
+            $_SESSION['error'] = "No previous move found, please restart or play";
+        }
+        else{
+        $stmt2 = $db->prepare('SELECT * FROM moves WHERE id = '.$result[5]);
+        $stmt2->execute();
+        $result2 = $stmt2->get_result()->fetch_array();
+        set_state($result2['state']);
+        }
+    }       
+    else{
+        $_SESSION['error'] = "You must play first";
+    }
 
-$db = include 'database.php';
-$stmt = $db->prepare('SELECT * FROM moves WHERE id = ' . $_SESSION['last_move']);
-$stmt->execute();
-$result = $stmt->get_result()->fetch_array();
-$_SESSION['last_move'] = $result[5];
-set_state($result[6]);
 header('Location: index.php');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         container_name: php-app
         ports:
           - "8000:80"
+        volumes:
+        - ./app/:/var/www/html/
 
     # MySQL database service
     app-db:

--- a/vendor/bin/.phpunit.result.cache
+++ b/vendor/bin/.phpunit.result.cache
@@ -1,1 +1,1 @@
-{"version":1,"defects":{"bug_tests::testIsValidMove":7},"times":{"bug_tests::testIsValidMove":0.01}}
+{"version":1,"defects":{"bug_tests::testIsValidMove":7,"bug_tests::testUndo":8},"times":{"bug_tests::testIsValidMove":0.01,"TestTiles::testGrasshopperHorizontalMove":0.391,"TestTiles::testDiagonalMove":0,"TestTiles::testGrasshopperMoveSamePosition":0,"TestTiles::testInvalidMove":0.019,"bug_tests::testAvailablePosition":0.009,"bug_tests::testUndo":0.463}}


### PR DESCRIPTION
The undo functionality checks for when undo is clicked when there are not any tiles played and it checks if there is no previous move, which requests the user for a restart. 

I made an attempt here to create the unit test for the first mentioned case. 

Besides that I added DeleteMove and getPreviousMove in database.php